### PR TITLE
feat: allow setting context reuse duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ console.log(`I ${canPrompt ? 'can' : 'cannot'} prompt for TouchID!`)
 
 * `options` Object
   * `reason` String - The reason you are asking for Touch ID authentication.
+  * `reuseDuration` Number - The duration for which Touch ID authentication reuse is allowable, in seconds.
 * `callback` Function
   * `error` - The reason authentication failed, if it failed.
 

--- a/index.js
+++ b/index.js
@@ -4,12 +4,15 @@ function promptTouchID(options, callback) {
   // Parse and sanitize options object
   if (!options) throw new Error('Options object is required.')
   else if (!options.hasOwnProperty('reason')) throw new Error('Reason parameter is required.')
-  else if (typeof options.reason !== 'string') throw new Error('Reason must be a string.')
+  else if (typeof options.reason !== 'string') throw new TypeError('Reason must be a string.')
+
+  // reuseDuration is optional
+  if (options.hasOwnProperty('reuseDuration') && typeof options.reuseDuration !== 'number') {
+    throw new TypeError('reuseDuration parameter must be a number.')
+  }
 
   // Ensure callback was passed and is a function
-  if (typeof callback !== 'function') {
-    throw new TypeError('Callback function is required.')
-  }
+  if (typeof callback !== 'function') throw new TypeError('Callback function is required.')
 
   auth.promptTouchID.call(this, options, callback)
 }
@@ -19,4 +22,3 @@ module.exports = {
   canPromptTouchID: auth.canPromptTouchID,
   promptTouchID
 }
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mac-auth",
-  "version": "0.0.1",
-  "description": "",
+  "name": "node-mac-auth",
+  "version": "0.1.0",
+  "description": "Query and handle native macOS biometric authentication.",
   "main": "index.js",
   "scripts": {
     "install": "node-gyp rebuild",

--- a/src/mac_auth.h
+++ b/src/mac_auth.h
@@ -3,4 +3,4 @@
 NAN_METHOD(CanPromptTouchID);
 NAN_METHOD(PromptTouchID);
 
-Nan::Utf8String* StringFromObject(v8::Local<v8::Object> object, const char* key);
+bool IsValid(v8::MaybeLocal<v8::Value> val);

--- a/src/mac_auth.mm
+++ b/src/mac_auth.mm
@@ -23,21 +23,42 @@ NAN_METHOD(PromptTouchID) {
   Nan::HandleScope scope;
 
   v8::Local<v8::Object> options = info[0].As<v8::Object>();
-  Nan::Utf8String *reason_utf8 = StringFromObject(options, "reason");
+  v8::Local<v8::String> reason_v8 = Nan::New("reason").ToLocalChecked();
+  v8::Local<v8::String> duration_v8 = Nan::New("reuseDuration").ToLocalChecked();
+
+  // Set defaults for options obj properties
+  int reuse_duration = 0;
+  std::string reason = "";
+
+  v8::MaybeLocal<v8::Value> reason_value = Nan::Get(options, reason_v8);
+  if (IsValid(reason_value))
+    reason = std::string(*Nan::Utf8String(reason_value.ToLocalChecked()->ToString()));
+
+  // reuseDuration is optional, so we can't assume that property exists on the object
+  if (Nan::HasOwnProperty(options, duration_v8).FromJust()) {
+    v8::MaybeLocal<v8::Value> duration_val = Nan::Get(options, duration_v8);
+    if (IsValid(reason_value))
+      reuse_duration = duration_val.ToLocalChecked()->NumberValue();
+  }
+
   Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
 
   if (@available(macOS 10.12.2, *)) {
-    auto* isolate = v8::Isolate::GetCurrent();
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
     LAContext *context = [[LAContext alloc] init];
     
     // The app-provided reason for requesting authentication
-    NSString *reason = [NSString stringWithUTF8String:**(reason_utf8)];
+    NSString *request_reason = [NSString stringWithUTF8String:reason.c_str()];
     
     // Authenticate with biometry.
     LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
 
+    // Optionally set the duration for which Touch ID authentication reuse is allowable
+    if (reuse_duration > 0)
+      [context setTouchIDAuthenticationAllowableReuseDuration:reuse_duration];
+
     [context evaluatePolicy:policy
-              localizedReason:reason
+              localizedReason:request_reason
               reply:^(BOOL success, NSError* error) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                   v8::Local<v8::Value> argv[1];
@@ -54,14 +75,8 @@ NAN_METHOD(PromptTouchID) {
   }
 }
 
-Nan::Utf8String* StringFromObject(v8::Local<v8::Object> object, const char* key) {
-  v8::Local<v8::String> key_handle = Nan::New(key).ToLocalChecked();
-  v8::MaybeLocal<v8::Value> handle = Nan::Get(object, key_handle);
-
-  if (handle.IsEmpty() || Nan::Equals(handle.ToLocalChecked(), Nan::Undefined()).FromJust()) {
-    Nan::ThrowTypeError("Invalid parameter.");
-    return nullptr;
-  }
-
-  return new Nan::Utf8String(handle.ToLocalChecked());
+bool IsValid(v8::MaybeLocal<v8::Value> val) {
+  if (val.IsEmpty() || Nan::Equals(val.ToLocalChecked(), Nan::Undefined()).FromJust()) 
+    return false;
+  return true;
 }


### PR DESCRIPTION
Allows users to set the duration for which Touch ID authentication reuse is allowable. From Apple [documentation](https://developer.apple.com/documentation/localauthentication/lacontext/1622329-touchidauthenticationallowablere?language=objc):

> If the user unlocks the device using Touch ID within the specified time interval, then authentication for the receiver succeeds automatically, without prompting the user for Touch ID. This bypasses a scenario where the user unlocks the device and then is almost immediately prompted for another fingerprint.

This also cleans up the argument sanitization and parsing at the C++ level.